### PR TITLE
chore: add org-level copilot instructions file

### DIFF
--- a/org-copilot-instructions.md
+++ b/org-copilot-instructions.md
@@ -7,3 +7,7 @@
 All commits must follow the [Conventional Commits](https://www.conventionalcommits.org/) format using the Angular preset.
 
 For detailed guidelines on commit types, scopes, and formatting rules, see the [release-composite-action README](https://github.com/agrc/release-composite-action/blob/main/README.md#commits).
+
+## Line Lengths
+
+You MUST enforce a maximum line length of 40 characters on all new code.

--- a/org-copilot-instructions.md
+++ b/org-copilot-instructions.md
@@ -1,6 +1,6 @@
 # UGRC General Copilot Instructions
 
-> Keep the copilot-instructions.md file concise (≤ ~2 pages). Update it whenever recurring clarification is needed.
+> Keep this per-repo Copilot instructions file concise (≤ ~2 pages). Update it whenever recurring clarification is needed.
 
 ## Commit Message Format
 

--- a/org-copilot-instructions.md
+++ b/org-copilot-instructions.md
@@ -1,0 +1,9 @@
+# UGRC General Copilot Instructions
+
+> Keep the copilot-instructions.md file concise (≤ ~2 pages). Update it whenever recurring clarification is needed.
+
+## Commit Message Format
+
+All commits must follow the [Conventional Commits](https://www.conventionalcommits.org/) format using the Angular preset.
+
+For detailed guidelines on commit types, scopes, and formatting rules, see the [release-composite-action README](https://github.com/agrc/release-composite-action/blob/main/README.md#commits).


### PR DESCRIPTION
This is just an idea. I wonder if we can reference this file in our project-level instruction files. For example: https://github.com/agrc/atlas/pull/578